### PR TITLE
Added clear command

### DIFF
--- a/lib/replicant/command.rb
+++ b/lib/replicant/command.rb
@@ -297,4 +297,22 @@ class LogcatCommand < Command
     AdbCommand.new(@repl, logcat).execute
   end
 
+class ClearCommand < Command
+
+  def description
+    "clear application data"
+  end
+
+  def valid_args?
+    args.empty?
+  end
+
+  def run
+    # Clear app data - cache, SharedPreferences, Databases
+    AdbCommand.new(@repl, "shell su -c \"rm -r /data/data/#{@repl.default_package}/*\"").execute
+    # Force application stop to recreate shared preferences, databases with new launch
+    AdbCommand.new(@repl, "shell am force-stop #{@repl.default_package}").execute
+  end
+end
+
 end


### PR DESCRIPTION
Added clear comment for clearing app data like cache, databases and shared preferences.
To use clear command rooted device or emulator is required.
