### PR TITLE
Added clear command

### DIFF
--- a/lib/replicant/command.rb
+++ b/lib/replicant/command.rb
@@ -305,13 +305,18 @@ class ClearCommand < Command
   end
 
   def valid_args?
-    args.empty?
+    args.length == 1 || (args.length == 0 && !@repl.default_package.nil?)
+  end
+
+  def usage
+    "#{name} [com.example.package|<empty>(when default package is set)]"
   end
 
   def run
+    package = args.length == 1 ? args.first : @repl.default_package
     # Clear app data - cache, SharedPreferences, Databases
-    AdbCommand.new(@repl, "shell su -c \"rm -r /data/data/#{@repl.default_package}/*\"").execute
+    AdbCommand.new(@repl, "shell su -c \"rm -r /data/data/#{package}/*\"").execute
     # Force application stop to recreate shared preferences, databases with new launch
-    AdbCommand.new(@repl, "shell am force-stop #{@repl.default_package}").execute
+    AdbCommand.new(@repl, "shell am force-stop #{package}").execute
   end
 end

--- a/lib/replicant/command.rb
+++ b/lib/replicant/command.rb
@@ -297,4 +297,22 @@ class LogcatCommand < Command
     AdbCommand.new(@repl, logcat).execute
   end
 
+class ClearCommand < Command
+
+  def description
+    "clear application data"
+  end
+
+  def valid_args?
+    args.empty?
+  end
+
+  def run
+    # Clear app data - cache, SharedPreferences, Databases
+    AdbCommand.new(@repl, "shell su -c \"rm -r /data/data/#{@repl.default_package}/*\"").execute
+    # Force application stop to recreate shared preferences, databases with new launch
+    AdbCommand.new(@repl, "shell am force-stop #{@repl.default_package}").execute
+  end
+end
+
 end

--- a/lib/replicant/command.rb
+++ b/lib/replicant/command.rb
@@ -296,6 +296,7 @@ class LogcatCommand < Command
     logcat << " | grep -E '\(\s*#{pid}\)'"
     AdbCommand.new(@repl, logcat).execute
   end
+end
 
 class ClearCommand < Command
 
@@ -313,6 +314,4 @@ class ClearCommand < Command
     # Force application stop to recreate shared preferences, databases with new launch
     AdbCommand.new(@repl, "shell am force-stop #{@repl.default_package}").execute
   end
-end
-
 end


### PR DESCRIPTION
Added clear comment for clearing app data like cache, databases and shared preferences.
To use clear command rooted device or emulator is required.
