### PR TITLE
Pass CTRL + C to the currently running adb command, if any

### DIFF
--- a/lib/replicant/command.rb
+++ b/lib/replicant/command.rb
@@ -92,10 +92,22 @@ class AdbCommand < Command
       else
         cmd << " #{@repl.default_package}" if @repl.default_package && package_dependent?
         output cmd if @repl.debug?
-        result = `#{cmd}`
-        output result
+
+        result, read = ""
+        @process = IO.popen(cmd)
+        while read = @process.gets
+          output read
+          result << read
+        end
+
         result
       end
+    end
+  end
+
+  def interrupt
+    if defined? @process
+      Process.kill("INT", @process.pid)
     end
   end
 
@@ -108,7 +120,7 @@ class AdbCommand < Command
   end
 
   def interactive?
-    args == "shell" || args.start_with?("logcat")
+    args == "shell"
   end
 
   def package_dependent?

--- a/lib/replicant/repl.rb
+++ b/lib/replicant/repl.rb
@@ -37,6 +37,15 @@ module Replicant
       # reset terminal colors on exit
       at_exit { puts unstyled }
 
+      # trap INT so that we can pass it to the current command, if necessary
+      trap("INT") {
+        if @command.is_a?(AdbCommand)
+          @command.interrupt
+        else
+          exit
+        end
+      }
+
       loop do
         command_loop
       end
@@ -53,13 +62,14 @@ module Replicant
 
       return if command_line.strip.empty?
 
-      command = Command.load(self, command_line)
-      if command
-        command.execute
+      @command = Command.load(self, command_line)
+      if @command
+        @command.execute
         puts span("OK.", :white_fg, :bold) { unstyled }
       else
         puts "No such command"
       end
+      @command = nil
     end
 
     def debug?


### PR DESCRIPTION
Allows exiting logcat and repeating loop situations (multiple devices
connected and no device selected) without killing Replicant itself.

GitHub: fixes #24
