### PR TITLE
Amend manifest search to work well with multi-projects builds

### DIFF
--- a/lib/replicant/repl.rb
+++ b/lib/replicant/repl.rb
@@ -160,23 +160,20 @@ module Replicant
           Find.prune if path.start_with?('./.') || path.split('/').size > 3
           if File.directory?(path)
             manifest_file_path = known_manifest_locations.map {|known_location| "#{path}/#{known_location}"}.find {|loc| File.exist?(loc)}
-            return manifest_file_path if manifest_file_path and is_application_path?(path)
+            return manifest_file_path if manifest_file_path and application_path?(path)
           end
         end
       end
     end
 
-    def is_application_path?(path)
+    def application_path?(path)
       if File.exists?("#{path}/project.properties") # old library project
-        return IO.readlines("#{path}/project.properties").find { |l| l =~ /android.library=true/ }.nil?
+        return IO.readlines("#{path}/project.properties").none? { |l| l =~ /android.library=true/ }
+      elsif File.exists?("#{path}/build.gradle")
+        return IO.readlines("#{path}/build.gradle").any { |l| l =~ /com.android.application/ }
       else
-        # TODO: support gradle files named something other than build.gradle.
-        if File.exists?("#{path}/build.gradle")
-          return not(IO.readlines("#{path}/build.gradle").find { |l| l =~ /com.android.application/ }.nil?)
-        end
+        true
       end
-
-      true
     end
 
     def get_package_from_manifest(manifest_path)


### PR DESCRIPTION
In my multi-project build, replicant would incorrectly set the package name of one of the sub-projects (which is a library project). I amended the implementation so that it looks for the manifest in the current directory and all sub-directories and checks if the sub-project is an app project. 

I couldn't really figure out how to do a couple of things properly, so suggestions are welcome:
1. if the current project is a library project, the package will be set to the one of the sample app, which is probably not what you want. But how can replicant know that's the case? A possibility would be to look for know app directory names like "sample", skip those and fall back to the library project.
2. how to write tests for this, on the other hand there weren't any for the previous implementation.
